### PR TITLE
Don't Render non-clicable Link

### DIFF
--- a/view/frontend/web/js/template/autocomplete/products.js
+++ b/view/frontend/web/js/template/autocomplete/products.js
@@ -34,6 +34,10 @@ define([], function () {
         },
 
         getFooterHtml: function ({html, ...resultDetails}) {
+            if( Object.keys(resultDetails).length < 1 ) {
+                return html;
+            }
+
             return html`<div id="autocomplete-products-footer">
                 ${this.getFooterSearchLinks(html, resultDetails)}
             </div>`;


### PR DESCRIPTION
**Summary**

Autocomplete will render a non-clickable link on a no results search.

**Result**
![image](https://github.com/user-attachments/assets/8a55606e-7032-4b7c-804e-5fc0d9495aa2)

**Steps to Recreate**
1. Navigate to a page that has Algolia Autocomplete enabled on it
2. Perform a search that will return no results
   - BUG: observe the link to **All Departments** is not clickable

